### PR TITLE
Migration from Debian 10 to Debian 12

### DIFF
--- a/mediathekview/docker/Dockerfile
+++ b/mediathekview/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM jlesage/baseimage-gui:debian-10-v4.8.2
+FROM jlesage/baseimage-gui:debian-12-v4.9.0
 
 # Kopiere Voraussetzungen
 COPY /mediathekview/docker/requirements.txt ./


### PR DESCRIPTION
Debian 10 has reached its end of life. Migrating the base image to Debian 12.