### PR TITLE
Upgrade Docker base image to Debian 13 (Bookworm -> Trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------
 # Stage 1: Build / Download MediathekView
 # ----------------------------------------
-FROM debian:12.13-slim AS builder
+FROM debian:13.4-slim@sha256:26f98ccd92fd0a44d6928ce8ff8f4921b4d2f535bfa07555ee5d18f61429cf0c AS builder
 
 # ----------------------------------------
 # Build-Argument
@@ -48,7 +48,7 @@ RUN mkdir -p /opt/MediathekView \
 # ----------------------------------------
 # Stage 2: Runtime
 # ----------------------------------------
-FROM jlesage/baseimage-gui:debian-12-v4.11.3
+FROM jlesage/baseimage-gui:debian-13-v4.11.3@sha256:a9dc8f37a5d0e7ca9246a1d1ac4c30b4aa5d515372af16057cfb62ed0254056f
 
 # Build-Argument
 ARG APP_VERSION


### PR DESCRIPTION
This PR migrates the Docker image from Debian 12 (Bookworm) to Debian 13.

The update brings newer system libraries, improved security, and prepares the image for future dependency updates. No functional changes intended beyond the base system upgrade.