### PR TITLE
Fix Mediathek Window Size Scaling

### DIFF
--- a/rootfs/etc/openbox/main-window-selection.xml
+++ b/rootfs/etc/openbox/main-window-selection.xml
@@ -1,2 +1,4 @@
-<Type>normal</Type>
-<Title>Mediathekview</Title>
+<main-window>
+    <Type>normal</Type>
+    <Title>MediathekView*</Title>
+</main-window>

--- a/rootfs/etc/openbox/rc.xml
+++ b/rootfs/etc/openbox/rc.xml
@@ -1,0 +1,7 @@
+<openbox_config>
+  <applications>
+    <application type="normal" title="MediathekView*">
+        <maximize>yes</maximize>
+    </application>
+  </applications>
+</openbox_config>


### PR DESCRIPTION
Dieser Pull Request behebt ein Problem mit der Fensterverwaltung von MediathekView im Docker‑Image, indem die Openbox‑Konfiguration angepasst wird, um das Hauptfenster korrekt zu handhaben und eine passende Fenstergröße zu gewährleisten.